### PR TITLE
sendgrid-php expects a modern version of guzzler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">= 5.3.0",
-    "guzzle/guzzle": ">= 3.0, < 3.5"
+    "guzzle/guzzle": ">= 3.0"
   },
   "require-dev": {
     "phpunit/phpunit": ">= 3.7.19",


### PR DESCRIPTION
According to https://github.com/honeybadger-io/honeybadger-php/issues/2,
honeybadger-php author gevans wasn't sure why this restriction was specifically there. going rogue and trying some shit.